### PR TITLE
グループ機能の実装-3 グループ作成の実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,13 +1,26 @@
 class GroupsController < ApplicationController
   def new
+    @group = Group.new
+    @group.users << current_user
   end
 
   def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, flashbox: "グループを作成しました"
+    else
+      render :new
+    end
   end
 
   def edit
   end
 
   def update
+  end
+
+  private
+  def group_params
+    params.require(:group).permit(:name, {:user_ids => []})
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,6 @@
 class Group < ApplicationRecord
-  has_many :users, through: :user_groups
-  has_many :user_groups
+  has_many :users, through: :group_users
+  has_many :group_users
   has_many :comments
 
   validates :name, presence: true, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :groups, through: :user_groups
-  has_many :user_groups
+  has_many :groups, through: :group_users
+  has_many :group_users
   has_many :comments
 end

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,27 +1,26 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form#new_chat_group.new_chat_group{"accept-charset": "UTF-8", action: "chat_groups", method: "post"}
-    %input{name: "utf8", type: "hidden", value:"✓"}/
-    %input{name: "authenticity_token", type: "hidden", value: "AxFKlYEhD6eqX1PiZoTYQDANtKvgcFSXZQXHt5hyTl55/U/CHC5rtPavrcu2za65riz4tekZEy56vP6kEb2wYA=="}/
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
+  = form_for @group do |f|
+    - if @group.errors.any?
+      .chat-group-form__errors
+        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
         %ul
-          %li エラーです
+          - @group.errors.full_messages.each do |message|
+            %li= messeage
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :name, class: "chat-group-form__label"
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, class: "chat_group_name chat-group-form__input", placeholder: "グループ名を入力してください"
     .chat-group-form__field
       / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label チャットメンバー
+        = f.label "チャットメンバー", class: "chat-group-form__label"
       .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        = f.collection_check_boxes :user_ids, User.all, :id, :name
         / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with": "Save", name: "commit", type: "submit", value: "Save"}/
+        = f.submit class: "chat-group-form__action-btn"


### PR DESCRIPTION
## Waht
グループ機能の実装を行う。
特に、グループ作成機能を主に実装する。

##Why
chat-spaceの根幹機能の一つであり、ユーザーに快適に使用してもらえるようにするため。

・group-controllerのnewアクション、createアクションに記述。privateメソッドと変数を定義。
・groupのnewビューのform関連タグを、全てform_forに書き換え。
・同ビューに、collection check boxを導入。
・modelファイルの、userとgroupのアソシエーションをuser_groupsからgroup_usersに変更。