### PR TITLE
グループ機能の実装-4　グループ名のサイドバー表示機能の実装

### DIFF
--- a/app/assets/stylesheets/index/_caption.scss
+++ b/app/assets/stylesheets/index/_caption.scss
@@ -5,7 +5,10 @@
   background-color: $side-bar;
   &__group{
     margin-bottom: 40px;
+    &--link {
     @include white();
+    text-decoration: none;
+    }
   }
   &__group--name {
     font-size:15px;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,7 @@
 class GroupsController < ApplicationController
+  def index
+  end
+  
   def new
     @group = Group.new
     @group.users << current_user

--- a/app/views/comments/_caption.html.haml
+++ b/app/views/comments/_caption.html.haml
@@ -1,5 +1,8 @@
 .caption
-  =link_to "/", class: "caption__link" do
-    .caption__group
-      %p.caption__group--name test-space
-      %p.caption__group--comment test
+  .caption__group
+    - current_user.groups.each do |group|
+      =link_to "/", class: "caption__group--link" do
+        .caption__group--name
+          = group.name
+        .caption__group--comment
+          メッセージはまだありません。


### PR DESCRIPTION
## What
グループ機能の実装を行う。
特にサイドバーにグループ名を表示する機能を実装する。

## Why
chat-spaceの根幹機能の一つであり、ユーザーに快適に使用してもらえるようにするため。

・groups-conntrollerにindexアクションを記述。
・ビューのテキスト記述を変更。
・関連するscssファイルを修正。