### PR TITLE
投稿機能の実装-3　メッセージ送信機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 .byebug_history
 
 public/uploads/*
+
+# Ignore uploaded files in development
+/public/uploads/

--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "haml-rails"
 gem "font-awesome-rails"
 gem "devise"
+gem "carrierwave"
+gem "mini_magick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,11 +38,20 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (7.1.4)
     bcrypt (3.1.13)
     bindex (0.8.1)
     builder (3.2.3)
     byebug (11.0.1)
+    carrierwave (2.0.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -81,6 +90,9 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.9.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.13, < 3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
@@ -96,6 +108,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mimemagic (0.3.3)
+    mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
@@ -104,6 +118,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (0.6.3)
@@ -138,6 +153,8 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.16)
+      ffi (~> 1.9)
     ruby_parser (3.14.0)
       sexp_processor (~> 4.9)
     sass (3.7.4)
@@ -190,6 +207,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   font-awesome-rails
@@ -197,6 +215,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)

--- a/app/assets/stylesheets/index/_send.scss
+++ b/app/assets/stylesheets/index/_send.scss
@@ -2,31 +2,33 @@
   height: 90px;
   padding: 20px 40px;
   background-color: $send-back;
-  &__space{
-    display: flex;
+}
+
+.new_comment{
+  display: flex;
+}
+
+.send__text {
+  width: 100%;
+  height: 50px;
+  padding: 0 40px 0 10px;
+  border-style: none;
+  color: $main-dark;
+  }
+
+.input-box__image {
+  position: relative;
+  &--file {
+    display: none;
   }
 }
 
-.input-box {
-  width: 100%;
-  position: relative;
-  &__text {
-    height: 50px;
-    width: 100%;
-    padding: 0 40px 0 10px;
-    border-style: none;
-    color: $main-dark;
-  }
-  &__image {
-    font-size: 1.3rem;
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    cursor: pointer;
-    &--file {
-      display: none;
-    }
-  }
+.icon {
+  font-size: 1.3rem;
+  position: absolute;
+  top: 16px;
+  right: 10px;
+  cursor: pointer;
 }
 
 input::placeholder{

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,13 +1,13 @@
 class CommentsController < ApplicationController
   before_action :set_group
 
-  def inedx
+  def index
     @comment = Comment.new
     @comments = @group.comments.includes(:user)
   end
 
   def create
-    @comment = @group.comments.new(comments_params)
+    @comment = @group.comments.new(comment_params)
     if @comment.save
       redirect_to group_comments_path(@group), notice: "コメントが送信されました"
     else
@@ -18,11 +18,11 @@ class CommentsController < ApplicationController
   end
 
   private
-    def comments_params
-      params.require(:comment).permit(:comment, :image).merge(user_id: current_user.id)
-    end
+  def comment_params
+    params.require(:comment).permit(:comment, :image).merge(user_id: current_user.id)
+  end
 
-    def set_group
-      @group = Group.find(params[:group_id])
-    end
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,28 @@
 class CommentsController < ApplicationController
+  before_action :set_group
+
   def inedx
+    @comment = Comment.new
+    @comments = @group.comments.includes(:user)
   end
 
   def create
+    @comment = @group.comments.new(comments_params)
+    if @comment.save
+      redirect_to group_comments_path(@group), notice: "コメントが送信されました"
+    else
+      @comments = @group.comments.includes(:user)
+      flash.now[:alert] = "コメントを入力してください"
+      render :index
+    end
   end
+
+  private
+    def comments_params
+      params.require(:comment).permit(:comment, :image).merge(user_id: current_user.id)
+    end
+
+    def set_group
+      @group = Group.find(params[:group_id])
+    end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,5 +4,5 @@ class Comment < ApplicationRecord
 
   validates :comment, presence: true, unless: :image?
   
-  mounnt_uploader :image, ImageUploader
+  mount_uploader :image, ImageUploader
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,7 @@ class Comment < ApplicationRecord
   belongs_to :group
   belongs_to :user
 
+  validates :comment, presence: true, unless: :image?
+  
   mounnt_uploader :image, ImageUploader
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,5 @@ class Comment < ApplicationRecord
   belongs_to :group
   belongs_to :user
 
-
+  mounnt_uploader :image, ImageUploader
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,5 @@ class Comment < ApplicationRecord
   belongs_to :group
   belongs_to :user
 
-  validates :comment, presence: true, unless: :image?
+
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,48 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+    process resize_to_fit: [800, 800]
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/comments/_caption.html.haml
+++ b/app/views/comments/_caption.html.haml
@@ -2,7 +2,7 @@
   - current_user.groups.each do |group|
     .caption
       = link_to group_comments_path(group) do
-        .caption__name
+        %p.caption__name
           = group.name
-        .caption__comment
+        %p.caption__comment
           メッセージはまだありません。

--- a/app/views/comments/_send.html.haml
+++ b/app/views/comments/_send.html.haml
@@ -1,10 +1,9 @@
 .send
-  %form.send__space{action: "", method: "post"}
-    =form_for "" do |f|
-      .input-box
-        %input.input-box__text{placeholder: "type a comment", type: "text", name: "comment-text"}
-        %label.input-box__image{for: "upload-icon"}
-          %i.fa.fa-image
-            =f.file_field :image, class: "input-box__image--file", id: "upload-icon"
-      %input.submit-btn{type: "submit", name: "send-btn", value: "Send"}
+  = form_for [@group, @comment] do |f|
+    = f.text_field :comment, class: "send__text", placeholder: "type a comment"
+    .input-box
+      = f.label :image, class: "input-box__image" do
+        = fa_icon "picture-o", class: "icon"
+        = f.file_field :image, class: "input-box__image--file"
+    = f.submit "Send", class: "submit-btn"
  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   root 'groups#index'
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
-    resources :comments, only: [:index, :cretae]
+    resources :comments, only: [:index, :create]
   end
 end


### PR DESCRIPTION
## What
chat-space投稿機能の実装。
特に、メッセージ送信機能の実装を行う。

## Why
chat-spaceのメイン機能であるため。

・gem、carrier waveとmini_magickを追加。
・uploderファイルを追加。
・commentモデルにcreateアクションを追加。
・commentコントローラーに各アクションを記述。
・viewファイル、_send.html.hamlをform_for記述に変更。
・_send.scssファイルの記述を変更。