### PR TITLE
投稿機能の実装-4 ビューへの表示

### DIFF
--- a/app/assets/stylesheets/index/_comment.scss
+++ b/app/assets/stylesheets/index/_comment.scss
@@ -3,14 +3,15 @@
   padding: 46px 40px;
   overflow: scroll;
   background-color: $comment-back-color;
-  &__text {
-    font-size: 14px;
-    padding-bottom: 10px;
-    color: $main-dark;
-  }
 }
 
-.comment-space {
+.comments__text {
+  font-size: 14px;
+  padding-bottom: 10px;
+  color: $main-dark;
+}
+
+.comments-space {
   padding-bottom: 40px;
   &__detail {
     display: flex;

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,12 @@ class Group < ApplicationRecord
   has_many :comments
 
   validates :name, presence: true, uniqueness: true
+
+  def show_last_comment
+    if (last_comment = comments.last).present?
+      last_comment.comment? ? last_comment.comment : "画像が投稿されています"
+    else
+      "まだコメントはありません"
+    end
+  end
 end

--- a/app/views/comments/_caption.html.haml
+++ b/app/views/comments/_caption.html.haml
@@ -5,4 +5,4 @@
         %p.caption__name
           = group.name
         %p.caption__comment
-          メッセージはまだありません。
+          = group.show_last_comment

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,6 +1,11 @@
-.comment
-  .comment-space
-    .comment-space__detail
-      %p.comment-space__detail--menber-name makurahumi
-      %p.comment-space__detail--date 2019/10/11(Fri) 12:00:00
-    %p.comment__text test
+.comments-space
+  .comments-space__detail
+    .comments-space__detail--menber-name
+      =comment.user.name
+    .comments-space__detail--date
+      =comment.created_at.strftime("%Y/%m/%d %H:%M")
+  .comments__text
+    - if comment.comment.present?
+      %p.comment__text--content
+        =comment.comment
+    = image_tag comment.image.url, class: "comment__tetx--image" if comment.image.present?

--- a/app/views/comments/_group-home.html.haml
+++ b/app/views/comments/_group-home.html.haml
@@ -1,9 +1,11 @@
 .group-home
   .group-home__detail
-    %h2.group-home__detail--current-group test-space
+    %h2.group-home__detail--current-group
+      = @group.name
     %ul.group-home__detail__menber--caption
-      Menber:
+      Menber :
       %li.group-home__detail__menber--list
-        makurahumi
+        - @group.users.each do |user|
+          = user.name
   =link_to "/groups/1/edit", class: "group-home__btn--edit" do
     Edit

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -5,5 +5,6 @@
   
   .main-menu
     =render partial: "comments/group-home"
-    =render partial: "comments/comment"
+    .comment
+      =render @comments
     =render partial: "comments/send"


### PR DESCRIPTION
## What
caht-space投稿機能の実装。
特にビューへの表示機能の実装を行う。

## Why
chat-spaceのメイン機能であるため。

・comment_indexとcomment.html.haml、comment.scssの各ファイルを表示に対応させるために修正。
・グループ名、所属ユーザー名、サイドバーへの最新コメントの表示を実装。